### PR TITLE
fix: [CV-4180] Find closest instead strict equality

### DIFF
--- a/kotlin-multiplatform/src/commonMain/kotlin/com/ricoh360/thetaclient/ThetaRepository.kt
+++ b/kotlin-multiplatform/src/commonMain/kotlin/com/ricoh360/thetaclient/ThetaRepository.kt
@@ -5630,6 +5630,10 @@ class ThetaRepository internal constructor(val endpoint: String, config: Config?
             fun get(value: Double): ShutterSpeedEnum? {
                 return ShutterSpeedEnum.values().firstOrNull { it.value == value }
             }
+
+            fun getClosest(value: Double): ShutterSpeedEnum? {
+                return ShutterSpeedEnum.values().minByOrNull { kotlin.math.abs(it.value - value) }
+            }
         }
     }
 


### PR DESCRIPTION
https://checkandvisit.atlassian.net/browse/CV-4180?search_id=a1ca2fe4-60da-458a-b31c-d0a8faac5019


Our library to read metadata give for example 
exposureTime=0.07692307692307693

Ricoh enum : 
```
/**
         * Shutter speed. 1/13 sec(0.07692307)
         */
        SHUTTER_SPEED_ONE_OVER_13(0.07692307),
```
        
        
      The old get was 
      `fun get(value: Double): ShutterSpeedEnum? {
    return ShutterSpeedEnum.values().firstOrNull { it.value == value }
}`

Now, find the closest instead strict equality 
       