### PR TITLE
feat: update Kotlin to 2.3.10

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
     // trick: for the same plugin versions in all sub-modules
     id("com.android.library").version("8.13.0").apply(false)
-    kotlin("multiplatform").version("2.2.10").apply(false)
-    kotlin("plugin.serialization").version("2.2.10").apply(false)
+    kotlin("multiplatform").version("2.3.10").apply(false)
+    kotlin("plugin.serialization").version("2.3.10").apply(false)
 }
 
 buildscript {

--- a/kotlin-multiplatform/build.gradle.kts
+++ b/kotlin-multiplatform/build.gradle.kts
@@ -2,7 +2,7 @@ import java.util.Properties
 
 plugins {
     kotlin("multiplatform")
-    kotlin("plugin.serialization") version "2.2.10"
+    kotlin("plugin.serialization") version "2.3.10"
     id("com.android.library")
     id("maven-publish")
     kotlin("native.cocoapods")


### PR DESCRIPTION
## Summary

- Update Kotlin plugin versions from 2.2.10 to 2.3.10 in `build.gradle.kts` and `kotlin-multiplatform/build.gradle.kts`
- Required to align with the main CommonInSpacerKit module which upgrades to Kotlin 2.3.10 for SKIE 0.10.10 support (better Swift export / async-await bridging)
- Without this change, Gradle fails with classpath conflicts (two different Kotlin plugin versions loaded)

## Test plan

- [x] CommonInSpacerKit Gradle build passes
- [x] iOS app runs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)